### PR TITLE
Update build.gradle to use maven instead of jcenter

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,11 +4,8 @@ def safeExtGet(prop, fallback) {
 
 buildscript {
     repositories {
-        jcenter()
         google()
-        maven {
-            url 'https://maven.google.com'
-        }
+        mavenCentral()
     }
 
     dependencies {
@@ -32,12 +29,9 @@ android {
 
 repositories {
     mavenCentral()
-    maven {
-        url 'https://maven.google.com'
-    }
+    mavenLocal()
 }
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
 }
-  

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-image-base64-png",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Convert PNG images to base64",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Bring fork up to date with https://github.com/tommyrharper/react-native-image-base64-png